### PR TITLE
Bug Fix For Null Interface Call

### DIFF
--- a/library/src/main/java/me/gujun/android/taggroup/TagGroup.java
+++ b/library/src/main/java/me/gujun/android/taggroup/TagGroup.java
@@ -792,7 +792,9 @@ class TagView extends AutoCompleteTextView {
                     @Override
                     public void afterTextChanged(Editable s) {
                         tagView = TagView.this;
+                       if(onTagCharEntryListener!=null && s !=null){
                         onTagCharEntryListener.onCharEntry(s.toString());
+                        }
                     }
                 });
 


### PR DESCRIPTION
There is an issue if the onTagCharEntryListener is not present for whatever reason coursing the library to crash internally if there is an internal error it should fail safely.